### PR TITLE
Fix(explicit-createref-type) allow type args

### DIFF
--- a/lib/rules/explicit-createref-type.js
+++ b/lib/rules/explicit-createref-type.js
@@ -1,23 +1,23 @@
-'use strict';
+"use strict";
 
 const explicitCreateRefTypeMessage = `React.createRef() class properties should be explicitly typed.`;
 
 module.exports = {
   meta: {
     messages: {
-      explicitCreateRefTypeMessage,
+      explicitCreateRefTypeMessage
     },
     docs: {
-      description: 'Force explicit type annotation on class properties storing a React.createRef()',
-      category: 'Best Practices',
+      description: "Force explicit type annotation on class properties storing a React.createRef()",
+      category: "Best Practices"
     },
     schema: [
       {
-        type: 'object',
+        type: "object",
         properties: {},
-        additionalProperties: false,
-      },
-    ],
+        additionalProperties: false
+      }
+    ]
   },
 
   create: function(context) {
@@ -28,20 +28,22 @@ module.exports = {
         }
 
         const value = node.value;
-        if (value != null && value.type === 'CallExpression') {
+        if (value != null && value.type === "CallExpression") {
           const callee = value.callee;
+          const typeArguments = value.typeArguments;
           if (
-            callee.type === 'MemberExpression' &&
-            callee.object.name === 'React' &&
-            callee.property.name === 'createRef'
+            callee.type === "MemberExpression" &&
+            callee.object.name === "React" &&
+            callee.property.name === "createRef" &&
+            typeArguments == null
           ) {
             context.report({
               node,
-              message: explicitCreateRefTypeMessage,
+              message: explicitCreateRefTypeMessage
             });
           }
         }
-      },
+      }
     };
-  },
+  }
 };

--- a/tests/lib/rules/explicit-createref-type.js
+++ b/tests/lib/rules/explicit-createref-type.js
@@ -1,10 +1,10 @@
-'use strict';
+"use strict";
 
-const rule = require('../../../lib/rules/explicit-createref-type');
-const parser = require.resolve('babel-eslint');
+const rule = require("../../../lib/rules/explicit-createref-type");
+const parser = require.resolve("babel-eslint");
 
 module.exports = ruleTester =>
-  ruleTester.run('explicit-createref-type', rule, {
+  ruleTester.run("explicit-createref-type", rule, {
     valid: [
       {
         parser,
@@ -19,8 +19,20 @@ class Test {
   c = React.createElement();
   d = {};
 }
-`,
+`
       },
+      {
+        parser,
+        code: `
+/* @flow */
+
+import * as React from 'react';
+
+class Test {
+  a = React.createRef<*>();
+}
+`
+      }
     ],
 
     invalid: [
@@ -31,7 +43,7 @@ class Test {
 import * as React from 'react';
 class Test { a = React.createRef(); }
 `,
-        errors: [{messageId: 'explicitCreateRefTypeMessage'}],
-      },
-    ],
+        errors: [{ messageId: "explicitCreateRefTypeMessage" }]
+      }
+    ]
   });


### PR DESCRIPTION
Now that we've upgraded babel & babel-eslint, we can use the fancier new
syntax for setting types on refs. This change enables

```js
class Foo {
  bar = React.createRef<*>()
}
```